### PR TITLE
Remove JVM options no longer needed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 }
 
 mainClassName = 'mqttloader.Loader'
-applicationDefaultJvmArgs = ['-Djava.util.logging.config.file=src/dist/logging.properties', '-Dfile.encoding=UTF-8', '--illegal-access=deny', '--add-opens=java.base/java.net=ALL-UNNAMED']
+applicationDefaultJvmArgs = ['-Djava.util.logging.config.file=src/dist/logging.properties', '-Dfile.encoding=UTF-8']
 
 repositories {
     mavenCentral()

--- a/doc/usage_en.md
+++ b/doc/usage_en.md
@@ -1,4 +1,4 @@
-# MQTTLoader usage (v0.8.0)
+# MQTTLoader usage (v0.8.1)
 MQTTLoader is a load testing tool (client tool) for MQTT.  
 It supports both MQTT v5.0 and v3.1.1.  
 From v0.8.0, it supports TLS authentication.
@@ -13,7 +13,7 @@ Download the archive file (zip or tar) from: https://github.com/dist-sys/mqttloa
 Below is an example of downloading by using curl command.
 
 ```
-$ curl -OL https://github.com/dist-sys/mqttloader/releases/download/v0.8.0/mqttloader-0.8.0.zip
+$ curl -OL https://github.com/dist-sys/mqttloader/releases/download/v0.8.1/mqttloader-0.8.1.zip
 ```
 
 By extracting it, you can get the following files.

--- a/doc/usage_jp.md
+++ b/doc/usage_jp.md
@@ -1,4 +1,4 @@
-# MQTTLoader 利用方法 (v0.8.0)
+# MQTTLoader 利用方法 (v0.8.1)
 MQTTLoaderは、MQTT v5.0とv3.1.1に対応した負荷テストツール（クライアントツール）です。  
 v0.8.0から、ブローカとのTLS接続にも対応しました。
 
@@ -14,7 +14,7 @@ https://github.com/dist-sys/mqttloader/releases
 以下は、Curlコマンドを使ってダウンロードする場合の例です。
 
 ```
-$ curl -OL https://github.com/dist-sys/mqttloader/releases/download/v0.8.0/mqttloader-0.8.0.zip
+$ curl -OL https://github.com/dist-sys/mqttloader/releases/download/v0.8.1/mqttloader-0.8.1.zip
 ```
 
 ダウンロードしたファイルを解凍すると、以下のディレクトリ構造が得られます。

--- a/src/main/java/mqttloader/Constants.java
+++ b/src/main/java/mqttloader/Constants.java
@@ -19,7 +19,7 @@ package mqttloader;
 import java.text.SimpleDateFormat;
 
 public class Constants {
-    public static final String VERSION = "0.8.0";
+    public static final String VERSION = "0.8.1";
     public static final String BROKER_PREFIX_TCP = "tcp://";
     public static final String BROKER_PREFIX_TLS = "ssl://";
     public static final String BROKER_PORT_TCP = "1883";


### PR DESCRIPTION
Remove the following JVM options in build.gradle:
- "--illegal-access=deny"
- "--add-opens=java.base/java.net=ALL-UNNAMED"