### PR TITLE
Support PEM format files for TLS configuration.

### DIFF
--- a/src/dist/mqttloader.conf
+++ b/src/dist/mqttloader.conf
@@ -83,22 +83,22 @@ log_level = INFO
 # user_name = john
 # password = mypassword
 
-## File path of truststore file in JKS (Java Key Store) format for TLS authentication. By specifying this parameter, TLS authentication is enabled.
-## e.g., C:\\Users\\testuser\\truststore.jks
+## Flag for enabling TLS authentication. You can specify "true" or "false".
+## DEFAULT: false
+# tls = false
+
+## File path of the root CA's certificate (PEM format). It must be a self-signed certificate.
+## If the certificate has already been stored in your trust store ("cacerts" file in the Java installation directory), you do not need to specify this parameter.
 ## DEFAULT: (not set)
-# tls_truststore = truststore.jks
+# tls_rootca_cert = C:\\Users\\testuser\\ca.crt
 
-## Password for the truststore file.
+## File path of the client's private key (PEM format).
+## By specifying this parameter, TLS client authentication is enabled.
 ## DEFAULT: (not set)
-# tls_truststore_pass = mypassword
+# tls_client_key = C:\\Users\\testuser\\client.key
 
-## File path of keystore file in JKS (Java Key Store) format for TLS client authentication. By specifying this parameter, TLS client authentication is enabled.
-## e.g., C:\\Users\\testuser\\keystore.jks
+## File paths of the client's certificate chain (PEM format).
+## Multiple paths must be separated by semicolons. Be sure not to include semicolons in file names or directory names.
+## The order must be from the client to the intermediate-CA(s). Root CA certificate is not necessarily.
 ## DEFAULT: (not set)
-# tls_keystore = keystore.jks
-
-## Password for the keystore file.
-## DEFAULT: (not set)
-# tls_keystore_pass = mypassword
-
-
+# tls_client_cert_chain = C:\\Users\\testuser\\client.crt;C:\\Users\\testuser\\ica.crt

--- a/src/main/java/mqttloader/Constants.java
+++ b/src/main/java/mqttloader/Constants.java
@@ -19,7 +19,7 @@ package mqttloader;
 import java.text.SimpleDateFormat;
 
 public class Constants {
-    public static final String VERSION = "0.8.3";
+    public static final String VERSION = "0.8.4";
     public static final String BROKER_PREFIX_TCP = "tcp://";
     public static final String BROKER_PREFIX_TLS = "ssl://";
     public static final String BROKER_PORT_TCP = "1883";
@@ -35,6 +35,7 @@ public class Constants {
     public static final long SECOND_IN_MICRO = 1000000L;
     public static final SimpleDateFormat DATE_FORMAT_FOR_LOG = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS z");
     public static final SimpleDateFormat DATE_FORMAT_FOR_FILENAME = new SimpleDateFormat("yyyyMMdd-HHmmss");
+    public static final int KEYSTORE_PASSWORD_LENGTH = 20;
 
     public enum Opt {
         CONFIG("c", true, "Configuration file's path.", "mqttloader.conf"),
@@ -106,10 +107,10 @@ public class Constants {
         OUTPUT("output"),
         USERNAME("user_name"),
         PASSWORD("password"),
-        TLS_TRUSTSTORE("tls_truststore"),
-        TLS_TRUSTSTORE_PASS("tls_truststore_pass"),
-        TLS_KEYSTORE("tls_keystore"),
-        TLS_KEYSTORE_PASS("tls_keystore_pass");
+        TLS("tls", "false"),
+        TLS_ROOTCA_CERT("tls_rootca_cert"),
+        TLS_CLIENT_CERT_CHAIN("tls_client_cert_chain"),
+        TLS_CLIENT_KEY("tls_client_key");
 
         private final String name;
         private final String defaultValue;
@@ -129,6 +130,30 @@ public class Constants {
 
         public String getDefaultValue() {
             return defaultValue;
+        }
+    }
+
+    public enum PemFormat {
+        PKCS1("-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----"),
+        PKCS8("-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"),
+        RFC5915("-----BEGIN EC PRIVATE KEY-----", "-----END EC PRIVATE KEY-----"),
+        RFC7468_CERT("-----BEGIN CERTIFICATE-----", "-----END CERTIFICATE-----"),
+        X509("-----BEGIN X509 CERTIFICATE-----", "-----END X509 CERTIFICATE-----");
+
+        private final String begin;
+        private final String end;
+
+        PemFormat(String begin, String end){
+            this.begin = begin;
+            this.end = end;
+        }
+
+        public String getBegin(){
+            return begin;
+        }
+
+        public String getEnd(){
+            return end;            
         }
     }
 }

--- a/src/main/java/mqttloader/Pem.java
+++ b/src/main/java/mqttloader/Pem.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Distributed Systems Group
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttloader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import mqttloader.Constants.PemFormat;
+
+public class Pem {
+	private final byte[] keyData;
+    private final List<byte[]> certDataList;
+    private PemFormat format;
+
+    public Pem(String filePath) {
+        List<String> originalLines = null;
+        try {
+            originalLines = Files.readAllLines(Paths.get(filePath), StandardCharsets.US_ASCII);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        List<String> parsedLines = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+
+        for(String line: originalLines){
+            PemFormat f = checkBeginString(line);
+            if(f!=null) {
+                format = f;
+                sb.append(line.replace(f.getBegin(), "").trim());
+            } else if((f=checkEndString(line))!=null) {
+                sb.append(line.replace(f.getEnd(), "").trim());
+                parsedLines.add(sb.toString().trim());
+                sb = new StringBuilder();
+            } else {
+                sb.append(line.trim());
+            }
+        }
+
+        if (format == PemFormat.RFC7468_CERT || format == PemFormat.X509) {
+            keyData = null;
+            certDataList = new ArrayList<byte[]>();
+            for (String line : parsedLines) {
+                certDataList.add(Base64.getDecoder().decode(line));
+            }
+        } else {
+            certDataList = null;
+            keyData = Base64.getDecoder().decode(parsedLines.get(0));
+        }
+    }
+
+    private PemFormat checkBeginString(String str){
+        for(PemFormat format: PemFormat.values()){
+            if(str.contains(format.getBegin())){
+                return format;
+            }
+        }
+        return null;
+    }
+
+    private PemFormat checkEndString(String str){
+        for(PemFormat format: PemFormat.values()){
+            if(str.contains(format.getEnd())){
+                return format;
+            }
+        }
+        return null;
+    }
+
+    public List<Certificate> getCerts() {
+        CertificateFactory certFactory;
+        List<Certificate> certs = null;
+        try {
+            certFactory = CertificateFactory.getInstance("X.509");
+            certs = new ArrayList<Certificate>();
+            for(byte[] certData : certDataList) { 
+                certs.add(certFactory.generateCertificate(new ByteArrayInputStream(certData)));
+            }
+        } catch (CertificateException e) {
+            e.printStackTrace();
+        }
+        return certs;
+    }
+
+    public PrivateKey getPrivateKey() {
+        KeySpec keySpec = null;
+        RuntimeException exception = new RuntimeException("Could not obtain Private Key.");
+
+        switch (format) {
+            case PKCS1: {
+                keySpec = parsePKCS1(keyData);
+                break;
+            }
+            case PKCS8: {
+                keySpec = new PKCS8EncodedKeySpec(keyData);
+                break;
+            }
+            default:
+                throw exception;
+        }
+
+        String[] algorithms = new String[]{"RSA", "DSA", "EC"};
+        for(String alg : algorithms){
+            try {
+                return KeyFactory.getInstance(alg).generatePrivate(keySpec);
+            } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+                exception.addSuppressed(e);
+            }
+        }
+        throw exception;
+    }
+
+    private KeySpec parsePKCS1(byte[] keyData) {
+        int pkcs1Length = keyData.length;
+        int pkcs8Length = pkcs1Length + 22; // As stated below, PKCS#8 needs 26 bytes in addition to PKCS#1 data. pkcs8Length is used as the value of SEQUENCE length and it does not include the first 4 bytes (0x30, 0x82, length-upper-byte, length-lower-byte).
+        byte[] pkcs8Header = new byte[] {
+            0x30,    // "SEQUENCE"
+            (byte) 0x82,    // "The following two bytes indicate the length of this field"
+            (byte) ((pkcs8Length >> 8) & 0xff), // Extract upper byte of the total length
+            (byte) (pkcs8Length & 0xff), // Extract lower byte of the total length
+            // Example: if total length is 294 bytes, 294 = 0x0126 = 0b 00000001 00100110 => 8bit right shift => 00000001 & 11111111 = 00000001
+            // 294 = 0x0126 = 0b 00000001 00100110 => 00000001 00100110 & 00000000 11111111 = 00100110
+            0x2,    // "INTEGER" for version
+            0x1,    // length: 1 byte
+            0x0,    // value: 0
+            0x30,   // "SEQUENCE" for privateKeyAlgorithm ID
+            0xD,    // length: 13 bytes
+            0x6,    // "OBJECT IDENTIFIER"
+            0x9,    // length: 9 bytes
+            0x2A, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xF7, 0xD, 0x1, 0x1, 0x1,  // value: 1.2.840.113549.1.1.1 - RSA encryption
+            0x5, 0x0, // "NULL" with length field 0x00
+            0x4,    // "OCTET STRING" for PKCS#1 data
+            (byte) 0x82,    // "The following two bytes indicate the length of this field"
+            (byte) ((pkcs1Length >> 8) & 0xff), // Extract upper byte
+            (byte) (pkcs1Length & 0xff) // Extract lower byte
+        };
+        byte[] pkcs8bytes = ByteBuffer.allocate(pkcs8Header.length + keyData.length).put(pkcs8Header).put(keyData).array();
+        return new PKCS8EncodedKeySpec(pkcs8bytes);
+    }
+}

--- a/src/main/java/mqttloader/Record.java
+++ b/src/main/java/mqttloader/Record.java
@@ -16,9 +16,7 @@
 
 package mqttloader;
 
-import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 public class Record {
     private long sentEpochMicros;


### PR DESCRIPTION
In the previous version, users who intend to use TLS authentication have to use the keytool command to generate JKS files.
From this version, MQTTLoader supports PEM format files; Users can use TLS authentication easier without the keytool command.