### PR TITLE
34# Issue: Reducing ClientID collision on mult process runnings

### DIFF
--- a/src/main/java/mqttloader/Constants.java
+++ b/src/main/java/mqttloader/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
     public static final String BROKER_PORT_TCP = "1883";
     public static final String BROKER_PORT_TLS = "8883";
     public static final String FILE_NAME_PREFIX = "mqttloader_";
-    private static final String HOST_ID = Util.genRandomChars(4);
+    private static final String HOST_ID = Util.genRandomChars(12);
     public static final String SUB_CLIENT_ID_PREFIX = "ml-"+HOST_ID+"-s-";
     public static final String PUB_CLIENT_ID_PREFIX = "ml-"+HOST_ID+"-p-";
     public static final Record STOP_SIGNAL = new Record();


### PR DESCRIPTION
To reduce the clientID conflits in experiments with multiple MQTTLoader process on the same target broker, was increased the HOST_ID constant size from 4 to 12.